### PR TITLE
Fixed readme, and fixed the flag error, of - to _

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ See the examples in training_samples/**
 ### Demo
 If you've downloaded the pre-trained model, you can setup a demo server by
 ```
-python3 run_demo_server.py --checkpoint-path /tmp/east_icdar2015_resnet_v1_50_rbox/
+python3 run_demo_server.py --checkpoint_path /tmp/east_icdar2015_resnet_v1_50_rbox/
 ```
 Then open http://localhost:8769 for the web demo. Notice that the URL will change after you submitted an image.
 Something like `?r=49647854-7ac2-11e7-8bb7-80000210fe80` appends and that makes the URL persistent.

--- a/run_demo_server.py
+++ b/run_demo_server.py
@@ -211,7 +211,7 @@ def main():
     global checkpoint_path
     parser = argparse.ArgumentParser()
     parser.add_argument('--port', default=8769, type=int)
-    parser.add_argument('--checkpoint-path', default=checkpoint_path)
+    parser.add_argument('--checkpoint_path', default=checkpoint_path)
     parser.add_argument('--debug', action='store_true')
     args = parser.parse_args()
     checkpoint_path = args.checkpoint_path


### PR DESCRIPTION
Fixed flag naming convention, that causes python to throw an error when running. See below from a hyphen - to underscore _.