### PR TITLE
Fixed the error when executing deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 mkdir -p server_log
-gunicorn -w 3 run_demo_server:app -b 0.0.0.0:8769 -t 120 \
-	--error-logfile server_log/error.log \
-	--access-logfile server_log/access.log
+GUNICORN_CMD_ARGS="-w 3 -b 0.0.0.0:8769 -t 120 \
+--error-logfile server_log/error.log \
+--access-logfile server_log/access.log" gunicorn run_demo_server:app


### PR DESCRIPTION
When I run the deploy.sh and submit a picture, I get some errors, and the resulting trace is:
```shell
Traceback (most recent call last):
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 135, in handle
    self.handle_request(listener, req, client, addr)
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/gunicorn/workers/sync.py", line 176, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/flask/app.py", line 2328, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/flask/app.py", line 2314, in wsgi_app
    response = self.handle_exception(e)
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/flask/app.py", line 1760, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/flask/_compat.py", line 36, in reraise
    raise value
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/flask/app.py", line 2311, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/flask/app.py", line 1834, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/flask/app.py", line 1737, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/flask/_compat.py", line 36, in reraise
    raise value
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/flask/app.py", line 1832, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/flask/app.py", line 1818, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/dao/project/EAST/run_demo_server.py", line 238, in index_post
    rst = get_predictor(checkpoint_path)(imgArr)
  File "/home/dao/project/EAST/run_demo_server.py", line 47, in get_predictor
    f_score, f_geometry = model.model(input_images, is_training=False)
  File "/home/dao/project/EAST/model.py", line 78, in model
    geo_map = slim.conv2d(g[3], 4, 1, activation_fn=tf.nn.sigmoid, normalizer_fn=None) * FLAGS.text_scale
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/tensorflow/python/platform/flags.py", line 84, in __getattr__
    wrapped(_sys.argv)
  File "/home/dao/anaconda2/envs/python36/lib/python3.6/site-packages/absl/flags/_flagvalues.py", line 633, in __call__
    name, value, suggestions=suggestions)
absl.flags._exceptions.UnrecognizedFlagError: Unknown command line flag 'w'
```
I found this error is similar to [How does tensorflow ignore undefined flags](https://stackoverflow.com/questions/48592296/how-does-tensorflow-ignore-undefined-flags), it is because the TensorFlow miss the undefined flags passed by gunicorn, a method is to use the environment variable GUNICORN_CMD_ARGS as [Settings-Gunicorn](http://docs.gunicorn.org/en/latest/settings.html).
I have tested this in Ubuntu 16.04, Python 3.6, TensorFlow 1.13.