### PR TITLE
Minus 1 is meaningless

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -56,8 +56,8 @@ def resize_image(im, max_side_len=2400):
     resize_h = int(resize_h * ratio)
     resize_w = int(resize_w * ratio)
 
-    resize_h = resize_h if resize_h % 32 == 0 else (resize_h // 32 - 1) * 32
-    resize_w = resize_w if resize_w % 32 == 0 else (resize_w // 32 - 1) * 32
+    resize_h = resize_h if resize_h % 32 == 0 else (resize_h // 32) * 32
+    resize_w = resize_w if resize_w % 32 == 0 else (resize_w // 32) * 32
     resize_h = max(32, resize_h)
     resize_w = max(32, resize_w)
     im = cv2.resize(im, (int(resize_w), int(resize_h)))


### PR DESCRIPTION
I don't know why we should minus 1 when resizing. Here is some examples in Python 3.6:
```Python
>>> (65//32-1)*32
32
```
Minus 1 will get some mathematic errors, 65 can't be resized to 32 when 64 is resized to 64.